### PR TITLE
Same sample ID

### DIFF
--- a/samplesheet/samplesheet_test_illumina_amplicon.csv
+++ b/samplesheet/samplesheet_test_illumina_amplicon.csv
@@ -2,4 +2,4 @@ sample,fastq_1,fastq_2
 SAMPLE1_PE,https://raw.githubusercontent.com/nf-core/test-datasets/viralrecon/illumina/amplicon/sample1_R1.fastq.gz,https://raw.githubusercontent.com/nf-core/test-datasets/viralrecon/illumina/amplicon/sample1_R2.fastq.gz
 SAMPLE2_PE,https://raw.githubusercontent.com/nf-core/test-datasets/viralrecon/illumina/amplicon/sample2_R1.fastq.gz,https://raw.githubusercontent.com/nf-core/test-datasets/viralrecon/illumina/amplicon/sample2_R2.fastq.gz
 SAMPLE3_SE,https://raw.githubusercontent.com/nf-core/test-datasets/viralrecon/illumina/amplicon/sample1_R1.fastq.gz,
-SAMPLE3_SE,https://raw.githubusercontent.com/nf-core/test-datasets/viralrecon/illumina/amplicon/sample2_R1.fastq.gz,
+SAMPLE4_SE,https://raw.githubusercontent.com/nf-core/test-datasets/viralrecon/illumina/amplicon/sample2_R1.fastq.gz,


### PR DESCRIPTION
The last two rows of the `samplesheet_test_illumina_amplicon.csv` share the same sample ID, which results in them being grouped together.

I may be mistaken, but I don’t think this is correct.

It would be nice to have a review in case it breaks any tests.