### PR TITLE
Add samplesheet without rundirs

### DIFF
--- a/testdata/NovaSeq6000/samplesheet_no_rundirs.csv
+++ b/testdata/NovaSeq6000/samplesheet_no_rundirs.csv
@@ -1,0 +1,6 @@
+sample,fastq_1,fastq_2,rundir,tags
+Sample1,https://github.com/nf-core/test-datasets/raw/seqinspector/testdata/NovaSeq6000/200624_A00834_0183_BHMTFYDRXX/Sample1_S1_L001_R1_001.fastq.gz,,,lane1:group1
+SampleA,https://github.com/nf-core/test-datasets/raw/seqinspector/testdata/NovaSeq6000/200624_A00834_0183_BHMTFYDRXX/SampleA_S2_L001_R1_001.fastq.gz,,,lane1:group1
+Sample23,https://github.com/nf-core/test-datasets/raw/seqinspector/testdata/NovaSeq6000/200624_A00834_0183_BHMTFYDRXX/Sample23_S3_L001_R1_001.fastq.gz,,,lane1:group2:test
+sampletest,https://github.com/nf-core/test-datasets/raw/seqinspector/testdata/NovaSeq6000/200624_A00834_0183_BHMTFYDRXX/sampletest_S4_L001_R1_001.fastq.gz,,,test
+Undetermined,https://github.com/nf-core/test-datasets/raw/seqinspector/testdata/NovaSeq6000/200624_A00834_0183_BHMTFYDRXX/Undetermined_S0_L001_R1_001.fastq.gz,,,test


### PR DESCRIPTION
This PR adds a sample sheet where no sample has a rundir specified in the samplesheet. This is needed for the changes in https://github.com/nf-core/seqinspector/pull/167