### PR TITLE
Adding toy samplesheet (synthetic data)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,38 +1,8 @@
 # ![nfcore/test-datasets](docs/images/test-datasets_logo.png)
 Test data to be used for automated testing with the nf-core pipelines
 
-> ⚠️ **Do not merge your test data to `master`! Each pipeline has a dedicated branch (and a special one for modules)**
+## Test data and samplesheets for Sopa
 
-## Introduction
+Some samplesheets are available under the `samplesheet` directory:
 
-nf-core is a collection of high quality Nextflow pipelines. This repository contains various files for CI and unit testing of nf-core pipelines and infrastructure.
-
-The principle for nf-core test data is as small as possible, as large as necessary. Please see the [guidelines](https://nf-co.re/docs/contributing/test_data_guidelines) for more detailed information. Always ask for guidance on the [nf-core slack](https://nf-co.re/join) before adding new test data.
-
-## Documentation
-
-nf-core/test-datasets comes with documentation in the `docs/` directory:
-
-01. [Add a new  test dataset](https://github.com/nf-core/test-datasets/blob/master/docs/ADD_NEW_DATA.md)
-02. [Use an existing test dataset](https://github.com/nf-core/test-datasets/blob/master/docs/USE_EXISTING_DATA.md)
-
-## Downloading test data
-
-Due the large number of large files in this repository for each pipeline, we highly recommend cloning only the branches you would use.
-
-```bash
-git clone <url> --single-branch --branch <pipeline/modules/branch_name>
-```
-
-To subsequently clone other branches[^1]
-
-```bash
-git remote set-branches --add origin [remote-branch]
-git fetch
-```
-
-## Support
-
-For further information or help, don't hesitate to get in touch on our [Slack organisation](https://nf-co.re/join/slack) (a tool for instant messaging).
-
-[^1]: From [stackoverflow](https://stackoverflow.com/a/60846265/11502856)
+- `toy.csv`: a toy samplesheet (under the hood, Sopa will create a synthetic dataset).

--- a/README.md
+++ b/README.md
@@ -5,4 +5,4 @@ Test data to be used for automated testing with the nf-core pipelines
 
 Some samplesheets are available under the `samplesheet` directory:
 
-- `toy.csv`: a toy samplesheet (under the hood, Sopa will create a synthetic dataset).
+- `toy.csv`: a toy samplesheet (under the hood, Sopa will create a synthetic dataset via [`sopa.io.toy_dataset`](https://gustaveroussy.github.io/sopa/api/readers/#sopa.io.toy_dataset)). This dataset is composed of two spatial elements (an image and a transcript dataframe) representing cells generated uniformly in a square.

--- a/samplesheet/toy.csv
+++ b/samplesheet/toy.csv
@@ -1,0 +1,2 @@
+sample,data_path
+sample_name,https://github.com/nf-core/test-datasets/blob/sopa/samplesheet/toy.csv


### PR DESCRIPTION
This is a dummy samplesheet. Under the hood, Sopa will create a synthetic toy dataset to run the tests.