### PR TITLE
Extend paraphase configuration

### DIFF
--- a/data/generic/config/paraphase_config.yaml
+++ b/data/generic/config/paraphase_config.yaml
@@ -6,3 +6,8 @@ PRODH:
   right_boundary: 18936792
   expect_cn2: True
   noisy_region: [[18913128, 18913160], [18921716, 18921743]]
+RIMBP3B:
+  genes: RIMBP3B,RIMBP3,RIMBP3C
+  realign_region: chr22:21380000-21390000
+  extract_regions: chr22:21380000-21390000 chr22:21544835-21554839 chr22:18605293-18615282
+


### PR DESCRIPTION
This PR extends paraphase's configuration with a new genomic region (taken from [PacBio's paraphase config](https://github.com/PacificBiosciences/paraphase/blob/main/paraphase/data/38/config.yaml)).

Rationale:  
Paraphase's test-dataset provides a [BAM file](https://github.com/nf-core/test-datasets/blob/modules/data/genomics/homo_sapiens/pacbio/bam/test.sorted.bam) which holds no reads in this newly-added genomic region.  
When paraphase analyzes a genomic region with no reads, it produces no output vcf/vcf-index files.  
By extending the above configuration with this genomic region, we can therefore verify that paraphase's ouput vcf/vcf-index files are indeed optional.