### PR TITLE
fix: Split mixed-compression sample in uncompressed samplesheet

### DIFF
--- a/samplesheet/v3.10/samplesheet_test_uncompressed.csv
+++ b/samplesheet/v3.10/samplesheet_test_uncompressed.csv
@@ -1,6 +1,6 @@
 sample,fastq_1,fastq_2,strandedness
 WT_REP1,https://raw.githubusercontent.com/nf-core/test-datasets/rnaseq/testdata/uncompressed/SRR6357070_1.fastq,https://raw.githubusercontent.com/nf-core/test-datasets/rnaseq/testdata/uncompressed/SRR6357070_2.fastq,auto
-WT_REP1,https://raw.githubusercontent.com/nf-core/test-datasets/rnaseq/testdata/GSE110004/SRR6357071_1.fastq.gz,https://raw.githubusercontent.com/nf-core/test-datasets/rnaseq/testdata/GSE110004/SRR6357071_2.fastq.gz,auto
+WT_REP1b,https://raw.githubusercontent.com/nf-core/test-datasets/rnaseq/testdata/GSE110004/SRR6357071_1.fastq.gz,https://raw.githubusercontent.com/nf-core/test-datasets/rnaseq/testdata/GSE110004/SRR6357071_2.fastq.gz,auto
 WT_REP2,https://raw.githubusercontent.com/nf-core/test-datasets/rnaseq/testdata/uncompressed/SRR6357072_1.fastq,https://raw.githubusercontent.com/nf-core/test-datasets/rnaseq/testdata/uncompressed/SRR6357072_2.fastq,reverse
 RAP1_UNINDUCED_REP1,https://raw.githubusercontent.com/nf-core/test-datasets/rnaseq/testdata/GSE110004/SRR6357073_1.fastq.gz,,reverse
 RAP1_UNINDUCED_REP2,https://raw.githubusercontent.com/nf-core/test-datasets/rnaseq/testdata/GSE110004/SRR6357074_1.fastq.gz,,reverse


### PR DESCRIPTION
## Summary

- Renames the compressed run of `WT_REP1` to `WT_REP1b` in `samplesheet/v3.10/samplesheet_test_uncompressed.csv`
- Previously, `WT_REP1` had two runs with different compression: one uncompressed `.fastq` and one compressed `.fastq.gz`
- `CAT_FASTQ` checks only the first file's extension to decide whether to pipe through gzip, so mixing compression within a sample produces corrupt output
- This supports [nf-core/rnaseq#1686](https://github.com/nf-core/rnaseq/pull/1686)

## Test plan

- [ ] Verify the samplesheet parses correctly in the rnaseq pipeline uncompressed FASTQ test

Generated with [Claude Code](https://claude.com/claude-code)