### PR TITLE
Add rgi card-data file

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,11 @@ The genomics folder contains subfolders for all organisms for which test data is
 Additionally there is a special subfolder for metagenome related files
 
 - metagenome
+  - fasta
+  - rgi
+  - taxonomy
+
+The `fasta` directory contains metagenomic sequence data, the `rgi` folder contains Resistance Gene Identifier data, and the `taxonomy` directory contains metadata for taxonomic classifier (TaxIDs, etc).
 
 All folders are structured in a similar way, with any genome-specific files in `genome` (e.g. fasta, gtf, ...) and technology specific raw-data files in the `10xgenomics`, `illumina`, `nanopore`, `pacbio`, `hic` and `cooler` subfolders whenever available.
 `Genomics` contains all typical data required for genomics modules, such as fasta, fastq and bam files. Every folder in `genomics` corresponds to a single organism. For every data file, a short description about how this file was generated is available either in this description or in the respective subfolder.

--- a/README.md
+++ b/README.md
@@ -40,7 +40,6 @@ Additionally there is a special subfolder for metagenome related files
   - rgi
   - taxonomy
 
-The `fasta` directory contains metagenomic sequence data, the `rgi` folder contains Resistance Gene Identifier data from the CARD database (May 2025 release, see https://card.mcmaster.ca/download for details), and the `taxonomy` directory contains metadata for taxonomic classifier (TaxIDs, etc).
 
 All folders are structured in a similar way, with any genome-specific files in `genome` (e.g. fasta, gtf, ...) and technology specific raw-data files in the `10xgenomics`, `illumina`, `nanopore`, `pacbio`, `hic` and `cooler` subfolders whenever available.
 `Genomics` contains all typical data required for genomics modules, such as fasta, fastq and bam files. Every folder in `genomics` corresponds to a single organism. For every data file, a short description about how this file was generated is available either in this description or in the respective subfolder.
@@ -299,6 +298,7 @@ The earth sciences folder contain subfolders for different data formats encounte
     - 'prot_nodes.dmp': sars-cov-2 dmp node file used for associated protein with tax ID (tested with DIAMOND). Subset from NCBI taxdmp nodes.dmp.
     - 'prot.accession2taxid.gz': sars-cov-2 ORF1ab polyprotein accession ID to tax id file, to match sars-cov-2 proteome.fasta
     - 'prot_seqid2taxid.map': taxonomy mapping file of the SARS-CoV2 proteome accession ID to the NCBI taxonomy ID
+    - 'card-data.tar.bz2': Resistance Gene Identifier data from the CARD database (May 2025 release, see https://card.mcmaster.ca/download for details)
 
 - homo_sapiens
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Additionally there is a special subfolder for metagenome related files
   - rgi
   - taxonomy
 
-The `fasta` directory contains metagenomic sequence data, the `rgi` folder contains Resistance Gene Identifier data, and the `taxonomy` directory contains metadata for taxonomic classifier (TaxIDs, etc).
+The `fasta` directory contains metagenomic sequence data, the `rgi` folder contains Resistance Gene Identifier data from the CARD database (May 2025 release, see https://card.mcmaster.ca/download for details), and the `taxonomy` directory contains metadata for taxonomic classifier (TaxIDs, etc).
 
 All folders are structured in a similar way, with any genome-specific files in `genome` (e.g. fasta, gtf, ...) and technology specific raw-data files in the `10xgenomics`, `illumina`, `nanopore`, `pacbio`, `hic` and `cooler` subfolders whenever available.
 `Genomics` contains all typical data required for genomics modules, such as fasta, fastq and bam files. Every folder in `genomics` corresponds to a single organism. For every data file, a short description about how this file was generated is available either in this description or in the respective subfolder.


### PR DESCRIPTION
Hi,

This PR also creates a `metagenomics` directory. Although there is already a `metagenome` directory under `data/genomics/prokaryotes/metagenome/`, there is a discussion in the `#modules` nf-core Slack channel to add more files for metagenomics testing.

I propose that `metagenomics` should be a directory under the `data/` directory, at the same level as `genomics` and `metabarcoding`. The `prokaryotes` directory where it currently sits contains mostly WGS data for model organisms, which is a different scope. This PR introduces this change. I would like to follow up with additional PRs to move content from the `data/genomics/prokaryotes/metagenome` to this new directory, fix the corresponding tests, and add more files for metagenomic testing.

cc @jfy133 @prototaxites @SPPearce 

Best,
Vini

---

**Summary of changes:**
- Add data for testing the rgi modules. See nf-core/modules#9873 for discussion.