### PR TITLE
nf-core bacass: replace ftp urls with https

### DIFF
--- a/bacass_full.csv
+++ b/bacass_full.csv
@@ -1,3 +1,3 @@
 ID	R1	R2	LongFastQ	Fast5	GenomeSize
-SRR10093028	ftp://ftp.sra.ebi.ac.uk/vol1/fastq/SRR100/028/SRR10093028/SRR10093028_1.fastq.gz	ftp://ftp.sra.ebi.ac.uk/vol1/fastq/SRR100/028/SRR10093028/SRR10093028_2.fastq.gz	NA	NA	NA
-SRR10093029	ftp://ftp.sra.ebi.ac.uk/vol1/fastq/SRR100/029/SRR10093029/SRR10093029_1.fastq.gz	ftp://ftp.sra.ebi.ac.uk/vol1/fastq/SRR100/029/SRR10093029/SRR10093029_2.fastq.gz	NA	NA	NA
+SRR10093028	https://ftp.sra.ebi.ac.uk/vol1/fastq/SRR100/028/SRR10093028/SRR10093028_1.fastq.gz	https://ftp.sra.ebi.ac.uk/vol1/fastq/SRR100/028/SRR10093028/SRR10093028_2.fastq.gz	NA	NA	NA
+SRR10093029	https://ftp.sra.ebi.ac.uk/vol1/fastq/SRR100/029/SRR10093029/SRR10093029_1.fastq.gz	https://ftp.sra.ebi.ac.uk/vol1/fastq/SRR100/029/SRR10093029/SRR10093029_2.fastq.gz	NA	NA	NA

--- a/bacass_full.tsv
+++ b/bacass_full.tsv
@@ -1,3 +1,3 @@
 ID	R1	R2	LongFastQ	Fast5	GenomeSize
-SRR10093028	ftp://ftp.sra.ebi.ac.uk/vol1/fastq/SRR100/028/SRR10093028/SRR10093028_1.fastq.gz	ftp://ftp.sra.ebi.ac.uk/vol1/fastq/SRR100/028/SRR10093028/SRR10093028_2.fastq.gz	NA	NA	NA
-SRR10093029	ftp://ftp.sra.ebi.ac.uk/vol1/fastq/SRR100/029/SRR10093029/SRR10093029_1.fastq.gz	ftp://ftp.sra.ebi.ac.uk/vol1/fastq/SRR100/029/SRR10093029/SRR10093029_2.fastq.gz	NA	NA	NA
+SRR10093028	https://ftp.sra.ebi.ac.uk/vol1/fastq/SRR100/028/SRR10093028/SRR10093028_1.fastq.gz	https://ftp.sra.ebi.ac.uk/vol1/fastq/SRR100/028/SRR10093028/SRR10093028_2.fastq.gz	NA	NA	NA
+SRR10093029	https://ftp.sra.ebi.ac.uk/vol1/fastq/SRR100/029/SRR10093029/SRR10093029_1.fastq.gz	https://ftp.sra.ebi.ac.uk/vol1/fastq/SRR100/029/SRR10093029/SRR10093029_2.fastq.gz	NA	NA	NA


### PR DESCRIPTION
Replace FTP URLs with HTTPS URLs due a time connection errors when attempting to download test_full dataset.

Closes #1872 
