### PR TITLE
Replace corrupted sample url file

### DIFF
--- a/bacass_full.csv
+++ b/bacass_full.csv
@@ -1,3 +1,3 @@
 ID	R1	R2	LongFastQ	Fast5	GenomeSize
-SRR10093028	https://ftp.sra.ebi.ac.uk/vol1/fastq/SRR100/028/SRR10093028/SRR10093028_1.fastq.gz	https://ftp.sra.ebi.ac.uk/vol1/fastq/SRR100/028/SRR10093028/SRR10093028_2.fastq.gz	NA	NA	NA
+SRR10092928	https://ftp.sra.ebi.ac.uk/vol1/fastq/SRR100/028/SRR10092928/SRR10092928_1.fastq.gz	https://ftp.sra.ebi.ac.uk/vol1/fastq/SRR100/028/SRR10092928/SRR10092928_2.fastq.gz	NA	NA	NA
 SRR10093029	https://ftp.sra.ebi.ac.uk/vol1/fastq/SRR100/029/SRR10093029/SRR10093029_1.fastq.gz	https://ftp.sra.ebi.ac.uk/vol1/fastq/SRR100/029/SRR10093029/SRR10093029_2.fastq.gz	NA	NA	NA

--- a/bacass_full.tsv
+++ b/bacass_full.tsv
@@ -1,3 +1,3 @@
 ID	R1	R2	LongFastQ	Fast5	GenomeSize
-SRR10093028	https://ftp.sra.ebi.ac.uk/vol1/fastq/SRR100/028/SRR10093028/SRR10093028_1.fastq.gz	https://ftp.sra.ebi.ac.uk/vol1/fastq/SRR100/028/SRR10093028/SRR10093028_2.fastq.gz	NA	NA	NA
+SRR10092928	https://ftp.sra.ebi.ac.uk/vol1/fastq/SRR100/028/SRR10092928/SRR10092928_1.fastq.gz	https://ftp.sra.ebi.ac.uk/vol1/fastq/SRR100/028/SRR10092928/SRR10092928_2.fastq.gz	NA	NA	NA
 SRR10093029	https://ftp.sra.ebi.ac.uk/vol1/fastq/SRR100/029/SRR10093029/SRR10093029_1.fastq.gz	https://ftp.sra.ebi.ac.uk/vol1/fastq/SRR100/029/SRR10093029/SRR10093029_2.fastq.gz	NA	NA	NA


### PR DESCRIPTION
## Fix corrupted test dataset in bacass pipeline

### Problem
The test dataset `SRR10093028_2.fastq.gz` was corrupted on the EBI FTP server, causing pipeline failures with `igzip: unexpected eof` errors. The file was truncated and missing quality scores for the final reads.

### Solution
- Replaced corrupted sample `SRR10093028` with working sample `SRR10092928`
- Updated test samplesheet with new URLs pointing to verified intact FASTQ files
- Maintained same data structure and format for compatibility

### Changes
- Updated R1 and R2 URLs to point to the new sample
- Verified file integrity of replacement sample

### Testing
- [x] Verified new FASTQ files download completely without corruption
- [x] Confirmed files pass `gunzip -t` integrity checks
- [x] Pipeline runs successfully with new test data
