### PR TITLE
Addition of the chr_order txt

### DIFF
--- a/data/genomics/eukaryotes/galaxea_fascicularis/hic/jaGalFasc40_2_chr_reordering.txt
+++ b/data/genomics/eukaryotes/galaxea_fascicularis/hic/jaGalFasc40_2_chr_reordering.txt
@@ -1,0 +1,6 @@
+scaffold_5
+scaffold_14
+scaffold_1
+scaffold_17
+scaffold_18
+scaffold_9


### PR DESCRIPTION
pretextsnapshot 0.6.0 adds the ability to reorder the output based on the contents of a single column txt file.

This PR adds a file for input to the snapshot module for this.