### PR TITLE
Add heterogeneous bacass test dataset for assembly_type=auto validation

### DIFF
--- a/bacass_auto_heterogeneous.csv
+++ b/bacass_auto_heterogeneous.csv
@@ -1,0 +1,4 @@
+ID,R1,R2,LongFastQ,Fast5,GenomeSize
+short_ERR044595,https://github.com/nf-core/test-datasets/raw/bacass/ERR044595_1M_1.fastq.gz,https://github.com/nf-core/test-datasets/raw/bacass/ERR044595_1M_2.fastq.gz,NA,NA,2.8m
+long_TestMe,NA,NA,https://github.com/nf-core/test-datasets/raw/bacass/nanopore/subset15000.fq.gz,NA,2.8m
+hybrid_ERR044595,https://github.com/nf-core/test-datasets/raw/bacass/ERR044595_1M_1.fastq.gz,https://github.com/nf-core/test-datasets/raw/bacass/ERR044595_1M_2.fastq.gz,https://github.com/nf-core/test-datasets/raw/bacass/nanopore/subset350.fq.gz,NA,2.8m

--- a/bacass_auto_heterogeneous.tsv
+++ b/bacass_auto_heterogeneous.tsv
@@ -1,0 +1,3 @@
+ID	R1	R2	LongFastQ	Fast5	GenomeSize
+short_ERR044595	https://github.com/nf-core/test-datasets/raw/bacass/ERR044595_1M_1.fastq.gz	https://github.com/nf-core/test-datasets/raw/bacass/ERR044595_1M_2.fastq.gz	NA	NA	2.8m
+long_TestMe	NA	NA	https://github.com/nf-core/test-datasets/raw/bacass/nanopore/subset15000.fq.gz	NA	2.8m

--- a/bacass_auto_heterogeneous.tsv
+++ b/bacass_auto_heterogeneous.tsv
@@ -1,3 +1,4 @@
 ID	R1	R2	LongFastQ	Fast5	GenomeSize
 short_ERR044595	https://github.com/nf-core/test-datasets/raw/bacass/ERR044595_1M_1.fastq.gz	https://github.com/nf-core/test-datasets/raw/bacass/ERR044595_1M_2.fastq.gz	NA	NA	2.8m
 long_TestMe	NA	NA	https://github.com/nf-core/test-datasets/raw/bacass/nanopore/subset15000.fq.gz	NA	2.8m
+hybrid_ERR044595	https://github.com/nf-core/test-datasets/raw/bacass/ERR044595_1M_1.fastq.gz	https://github.com/nf-core/test-datasets/raw/bacass/ERR044595_1M_2.fastq.gz	https://github.com/nf-core/test-datasets/raw/bacass/nanopore/subset350.fq.gz	NA	2.8m


### PR DESCRIPTION
## PR Description

This PR adds a new heterogeneous bacass test dataset combining:
- one **short-read only** sample
- one **long-read only** sample

### Added file
- `bacass_auto_heterogeneous.tsv`