### PR TITLE
Move proteinfold files from v1.2 to v2.0

### DIFF
--- a/testdata/samplesheet/v2.0/samplesheet.csv
+++ b/testdata/samplesheet/v2.0/samplesheet.csv
@@ -1,4 +1,3 @@
 id,fasta
 T1024,https://raw.githubusercontent.com/nf-core/test-datasets/proteinfold/testdata/sequences/T1024.fasta
 T1026,https://raw.githubusercontent.com/nf-core/test-datasets/proteinfold/testdata/sequences/T1026.fasta
-

--- a/testdata/samplesheet/v2.0/samplesheet_multimer.csv
+++ b/testdata/samplesheet/v2.0/samplesheet_multimer.csv
@@ -1,3 +1,2 @@
 id,fasta
 H1065,https://raw.githubusercontent.com/nf-core/test-datasets/proteinfold/testdata/sequences/H1065.fasta
-

--- a/testdata/samplesheet/v2.0/samplesheet_single_fasta.csv
+++ b/testdata/samplesheet/v2.0/samplesheet_single_fasta.csv
@@ -1,0 +1,2 @@
+id,fasta
+T1026,https://raw.githubusercontent.com/nf-core/test-datasets/proteinfold/testdata/sequences/T1026.fasta


### PR DESCRIPTION
The minor version v1.2 will be a major v2.0 thus files are moved and v1.2 is removed