### PR TITLE
Adjusting Comet testdata

### DIFF
--- a/README.md
+++ b/README.md
@@ -1002,8 +1002,8 @@ The earth sciences folder contain subfolders for different data formats encounte
   - 'HepG2_rep1_small.idXML': Identification file in idXML format
   - 'HepG2_rep2_small.idXML': Identification file in idXML format
 - parameter
-  - 'comet.params': Default Comet params file (high-high setting, parameters will be adjusted accordingly during call of Comet module)
   - 'mqpar.xml': MaxQuant parameter file
+  - 'OVEMB150205.comet.params': Comet params file for the OVEMB150205.* raw and mzML files (database and CPUs will be set accordingly during call of Comet module)
   - 'sage_base_config.json': Sage parameter file
 - pdb
   - 1tim.pdb: Triose phosphate isomerase, through X-ray diffraction (Chicken muscle - Engineered)

--- a/data/proteomics/parameter/OVEMB150205.comet.params
+++ b/data/proteomics/parameter/OVEMB150205.comet.params
@@ -1,4 +1,4 @@
-# comet_version 2026.01 rev. 0
+# comet_version 2026.01 rev. 1 (9df704c)
 # Comet MS/MS search engine parameters file.
 # Everything following the '#' symbol is treated as a comment.
 #
@@ -6,6 +6,25 @@ database_name = /some/path/db.fasta
 decoy_search = 0                       # 0=no (default), 1=internal decoy concatenated, 2=internal decoy separate
 
 num_threads = 0                        # 0=poll CPU to set num threads; else specify num threads directly (max 128)
+
+spectral_library_name =
+#spectral_library_ms_level = 1
+
+#
+# PEFF - PSI Extended FASTA Format
+#
+peff_format = 0                        # 0=no (normal fasta, default), 1=PEFF PSI-MOD, 2=PEFF Unimod
+peff_obo =                             # path to PSI Mod or Unimod OBO file
+
+#
+# fragment ion index; limited to 5 variable mods and up to 5 modified residues per mod
+#
+fragindex_min_ions_score = 3           # minimum number of matched fragment ion index peaks for scoring
+fragindex_min_ions_report = 3          # minimum number of matched fragment ion index peaks for reporting(>= fragindex_min_ions_score)
+fragindex_num_spectrumpeaks = 100      # number of peaks from spectrum to use for fragment ion index matching
+fragindex_min_fragmentmass = 200.0     # low mass cutoff for fragment ions
+fragindex_max_fragmentmass = 2000.0    # high mass cutoff for fragment ions
+fragindex_skipreadprecursors = 0       # 0=read precursors to limit fragment ion index, 1=skip reading precursors
 
 #
 # masses
@@ -15,6 +34,8 @@ peptide_mass_tolerance_lower = -20.0   # lower bound of the precursor mass toler
 peptide_mass_units = 2                 # 0=amu, 1=mmu, 2=ppm
 precursor_tolerance_type = 1           # 0=MH+ (default), 1=precursor m/z; only valid for amu/mmu tolerances
 isotope_error = 2                      # 0=off, 1=0/1 (C13 error), 2=0/1/2, 3=0/1/2/3, 4=-1/0/1/2/3, 5=-1/0/1
+mass_type_parent = 1                   # 0=average masses, 1=monoisotopic masses
+mass_type_fragment = 1                 # 0=average masses, 1=monoisotopic masses
 
 #
 # search enzyme
@@ -36,8 +57,19 @@ variable_mod02 = 0.0 X 0 3 -1 0 0 0.0
 variable_mod03 = 0.0 X 0 3 -1 0 0 0.0
 variable_mod04 = 0.0 X 0 3 -1 0 0 0.0
 variable_mod05 = 0.0 X 0 3 -1 0 0 0.0
+variable_mod06 = 0.0 X 0 3 -1 0 0 0.0
+variable_mod07 = 0.0 X 0 3 -1 0 0 0.0
+variable_mod08 = 0.0 X 0 3 -1 0 0 0.0
+variable_mod09 = 0.0 X 0 3 -1 0 0 0.0
+variable_mod10 = 0.0 X 0 3 -1 0 0 0.0
+variable_mod11 = 0.0 X 0 3 -1 0 0 0.0
+variable_mod12 = 0.0 X 0 3 -1 0 0 0.0
+variable_mod13 = 0.0 X 0 3 -1 0 0 0.0
+variable_mod14 = 0.0 X 0 3 -1 0 0 0.0
+variable_mod15 = 0.0 X 0 3 -1 0 0 0.0
 max_variable_mods_in_peptide = 5
 require_variable_mod = 0
+protein_modslist_file =                # limit variable mods to subset of specified proteins if this file is specified & present
 
 #
 # fragment ions
@@ -45,7 +77,7 @@ require_variable_mod = 0
 # ion trap ms/ms:  1.0005 tolerance, 0.4 offset (mono masses), theoretical_fragment_ions = 1
 # high res ms/ms:    0.02 tolerance, 0.0 offset (mono masses), theoretical_fragment_ions = 0, spectrum_batch_size = 15000
 #
-fragment_bin_tol = 0.02                # binning to use on fragment ions
+fragment_bin_tol = 0.2
 fragment_bin_offset = 0.0              # offset position to start the binning (0.0 to 1.0)
 theoretical_fragment_ions = 0          # 0=use flanking peaks, 1=M peak only
 use_A_ions = 0
@@ -65,6 +97,8 @@ output_txtfile = 1                     # 0=no, 1=yes  write tab-delimited txt fi
 output_pepxmlfile = 0                  # 0=no, 1=yes  write pepXML file
 output_mzidentmlfile = 1               # 0=no, 1=yes  write mzIdentML file
 output_percolatorfile = 0              # 0=no, 1=yes  write Percolator pin file
+print_expect_score = 1                 # 0=no, 1=yes to replace Sp with expect in out & sqt
+print_ascorepro_score = 1              # 0=no, 0 to 5 to localize variable_mod01 to _mod05; -1 to localize all variable mods
 num_output_lines = 1                   # num peptide results to show
 
 #
@@ -81,6 +115,8 @@ activation_method = ALL                # activation method; used if activation m
 #
 digest_mass_range = 600.0 5000.0       # MH+ peptide mass range to analyze
 peptide_length_range = 5 50            # minimum and maximum peptide length to analyze (default min 1 to allowed max 51)
+pinfile_protein_delimiter =            # blank = default 'tab' delimiter between proteins; enter a char/string to use in place of the tab; Percolator pin output only
+num_results = 100                      # number of results to store internally for Sp rank only; if Sp rank is not used, set this to num_output_lines
 max_duplicate_proteins = 10            # maximum number of additional duplicate protein names to report for each peptide ID; -1 reports all duplicates
 max_fragment_charge = 3                # set maximum fragment charge state to analyze (allowed max 5)
 min_precursor_charge = 1               # set minimum precursor charge state to analyze (1 if missing)
@@ -95,7 +131,7 @@ mass_offsets =                         # one or more mass offsets to search (val
 # spectral processing
 #
 minimum_peaks = 10                     # required minimum number of peaks in spectrum to search (default 10)
-minimum_intensity = 0.001              # minimum intensity value to read in
+minimum_intensity = 0                  # minimum intensity value to read in
 remove_precursor_peak = 0              # 0=no, 1=yes, 2=all charge reduced precursor peaks (for ETD), 3=phosphate neutral loss peaks
 remove_precursor_tolerance = 1.5       # +- Da tolerance for precursor removal
 clear_mz_range = 0.0 0.0               # clear out all peaks in the specified m/z range e.g. remove reporter ion region of TMT spectra

--- a/data/proteomics/parameter/comet.params
+++ b/data/proteomics/parameter/comet.params
@@ -61,9 +61,9 @@ use_NL_ions = 0                        # 0=no, 1=yes to consider NH3/H2O neutral
 # output
 #
 output_sqtfile = 0                     # 0=no, 1=yes  write sqt file
-output_txtfile = 0                     # 0=no, 1=yes  write tab-delimited txt file
-output_pepxmlfile = 1                  # 0=no, 1=yes  write pepXML file
-output_mzidentmlfile = 0               # 0=no, 1=yes  write mzIdentML file
+output_txtfile = 1                     # 0=no, 1=yes  write tab-delimited txt file
+output_pepxmlfile = 0                  # 0=no, 1=yes  write pepXML file
+output_mzidentmlfile = 1               # 0=no, 1=yes  write mzIdentML file
 output_percolatorfile = 0              # 0=no, 1=yes  write Percolator pin file
 num_output_lines = 5                   # num peptide results to show
 

--- a/data/proteomics/parameter/comet.params
+++ b/data/proteomics/parameter/comet.params
@@ -65,7 +65,7 @@ output_txtfile = 1                     # 0=no, 1=yes  write tab-delimited txt fi
 output_pepxmlfile = 0                  # 0=no, 1=yes  write pepXML file
 output_mzidentmlfile = 1               # 0=no, 1=yes  write mzIdentML file
 output_percolatorfile = 0              # 0=no, 1=yes  write Percolator pin file
-num_output_lines = 5                   # num peptide results to show
+num_output_lines = 1                   # num peptide results to show
 
 #
 # mzXML/mzML/raw file parameters


### PR DESCRIPTION
The test data for comet had default settings, which I wanted to set in the Comet module.
This approach though breaks some nf-core defaults, so I changed the parameter file to be specific to the provided spectra file and adjusted the (upcomoing) module. No larger breaks there, only moving the logic slightly.